### PR TITLE
quick fix disabled input thesaurus with default value

### DIFF
--- a/Front/app/ns_modules/ns_bbfe/bbfe-autocompTree.js
+++ b/Front/app/ns_modules/ns_bbfe/bbfe-autocompTree.js
@@ -161,6 +161,9 @@ define([
             if (_this.value) {
                 _this.$el.find('#' + _this.id).val(_this.value.displayValue);
                 _this.$el.find('#' + _this.id + '_value').val(_this.value.value);
+                if(!_this.editable){
+                    _this.$el.find('#' + _this.id).attr('val',_this.value.value);
+                }
             }
 
             }).defer();
@@ -186,6 +189,10 @@ define([
             //if empty val
             if(!this.$el.find('#' + this.id).val()){
                 return '';
+            }
+
+            if(!this.editable && this.$el.find('#' + this.id).attr('val')){
+                return this.$el.find('#' + this.id).attr('val');
             }
 
             if ( this.$el.find('#' + this.id + '_value') ){


### PR DESCRIPTION
before this fix, no value was sent for disabled input thesaurus with default value in form in edit mode, because hidden input with treeview which stored the value not exists in display mode. 
See Individual equipment with sensor status