### PR TITLE
Hotfix save from criteria

### DIFF
--- a/Front/app/ns_modules/ns_bbfe/bbfe-autocompTree.js
+++ b/Front/app/ns_modules/ns_bbfe/bbfe-autocompTree.js
@@ -157,6 +157,13 @@ define([
 
             }
 
+            if((typeof _this.value === "string") && _this.value != null && _this.value != 'null' && _this.value != ''){
+                var tmp = _this.value;
+                _this.value = {};
+                _this.value.value = tmp;
+                _this.value.displayValue = _this.findDisplayedValue(tmp);
+            }
+
             //set inital values
             if (_this.value) {
                 _this.$el.find('#' + _this.id).val(_this.value.displayValue);
@@ -166,6 +173,20 @@ define([
             }).defer();
 
             return this;
+        },
+
+        findDisplayedValue: function(value){
+            var _this = this;
+
+            var node = this.$el.find('#treeView' + this.id).fancytree('getTree').findFirst(function(node){
+                return (node.data.fullpath == value)
+            });
+            if(node){
+                return node.data.valueTranslated;    
+            } else {
+                return '';
+            }
+            
         },
 
         isEmptyVal: function(value){

--- a/Front/app/ns_modules/ns_bbfe/bbfe-objectPicker/bbfe-objectPicker.js
+++ b/Front/app/ns_modules/ns_bbfe/bbfe-objectPicker/bbfe-objectPicker.js
@@ -359,7 +359,12 @@ define([
             ctx.filters.update();
             data = {};
             for (var i = 0; i < ctx.filters.criterias.length; i++) {
-              data[ctx.filters.criterias[i]['Column']] = ctx.filters.criterias[i]['Value'] === 'null' ? '': ctx.filters.criterias[i]['Value'];
+              if( ctx.filters.criterias[i]['Operator'] == 'Is') {
+                data[ctx.filters.criterias[i]['Column']] = ctx.filters.criterias[i]['Value'] === 'null' ? '': ctx.filters.criterias[i]['Value'];
+              }
+              else {
+                data[ctx.filters.criterias[i]['Column']] = ''
+              }
             }
           } else {
             data = {};


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/145518189

Problem to pass filter defined to save from criteria

now it's fixed and we only keep value where operator equals 'Is' 
to fill input with it in the form for creating new individual