### PR TITLE
fix pb when saving property not in table column

### DIFF
--- a/Back/ecoreleve_server/GenericObjets/DataBaseObjects.py
+++ b/Back/ecoreleve_server/GenericObjets/DataBaseObjects.py
@@ -164,10 +164,10 @@ class DbObject(object):
     def setProperty(self, propertyName, value):
         ''' Set object properties (static and dynamic) '''
         if hasattr(self, propertyName):
-                if propertyName in self.__table__.c:
-                    value = parser(value)
+            if propertyName in self.__table__.c:
+                value = parser(value)
                 setattr(self, propertyName, value)
-                self.__properties__[propertyName] = value
+            self.__properties__[propertyName] = value
 
     def updateFromJSON(self, data, startDate=None):
         ''' Function to call : update properties of new

--- a/Back/ecoreleve_server/GenericObjets/DataBaseObjects.py
+++ b/Back/ecoreleve_server/GenericObjets/DataBaseObjects.py
@@ -166,8 +166,9 @@ class DbObject(object):
         if hasattr(self, propertyName):
             if propertyName in self.__table__.c:
                 value = parser(value)
+            if propertyName not in ['Status_']:
                 setattr(self, propertyName, value)
-            self.__properties__[propertyName] = value
+                self.__properties__[propertyName] = value
 
     def updateFromJSON(self, data, startDate=None):
         ''' Function to call : update properties of new


### PR DESCRIPTION
fix #557 

https://www.pivotaltracker.com/story/show/146680607

quick fix Back end problem

When we try to update any property of individual
API return 500 
because front send property "status_"
but "status_" is a calculated prop  (from individualStatus View in database)
and back try to setattr()

I don't know if it's the good way to fix it but that's work.


**edit **

Not the good way , now we cant edit vertebrate group and add individuals 

we will see tomorrow 


** edit **

dirty fix just skeep if propertyname = Status_