### PR TITLE
Hot fix leaving grid when editing

### DIFF
--- a/Front/app/app.js
+++ b/Front/app/app.js
@@ -250,12 +250,6 @@ function( Marionette, LytRootView, Router, Controller,Swal,config, $, Backbone) 
             //         }
             //     });
           // }
-            if( typeof(window.formInEdition.form['.js-rg-grid']) !='undefined'  ) {
-              delete window.formInEdition.form['.js-rg-grid'];
-            }
-            if( typeof(window.formInEdition.form['.js-rg-grid-subform']) !='undefined'  ) {
-              delete window.formInEdition.form['.js-rg-grid-subform'];
-            }
            // if (typeof(window.formInEdition['']))
               if(indexMax-urlChangeMax<=0){
                 window.formInEdition = {};

--- a/Front/app/app.js
+++ b/Front/app/app.js
@@ -250,6 +250,13 @@ function( Marionette, LytRootView, Router, Controller,Swal,config, $, Backbone) 
             //         }
             //     });
           // }
+            if( typeof(window.formInEdition.form['.js-rg-grid']) !='undefined'  ) {
+              delete window.formInEdition.form['.js-rg-grid'];
+            }
+            if( typeof(window.formInEdition.form['.js-rg-grid-subform']) !='undefined'  ) {
+              delete window.formInEdition.form['.js-rg-grid-subform'];
+            }
+           // if (typeof(window.formInEdition['']))
               if(indexMax-urlChangeMax<=0){
                 window.formInEdition = {};
               }

--- a/Front/app/modules/release/release.individual.view.js
+++ b/Front/app/modules/release/release.individual.view.js
@@ -117,7 +117,7 @@ define([
         url: 'release/individuals/',
         gridOptions: {
           enableFilter: true,
-          editType: 'fullRow',
+          //editType: 'fullRow',
           singleClickEdit : true,
           rowSelection: 'multiple',
           onCellValueChanged : _this.checkAll.bind(_this),

--- a/Front/app/modules/stations/protocols/protocol.grid.view.js
+++ b/Front/app/modules/stations/protocols/protocol.grid.view.js
@@ -182,7 +182,7 @@ define([
         objectType: this.model.get('ID'),
         displayRowIndex: true,
         gridOptions: {
-          editType: 'fullRow',
+          //editType: 'fullRow',
           singleClickEdit : true,
           rowData: rowData,
           rowSelection: (this.editable)? 'multiple' : '',

--- a/Front/app/ns_modules/ns_bbfe/bbfe-gridForm.js
+++ b/Front/app/ns_modules/ns_bbfe/bbfe-gridForm.js
@@ -121,7 +121,7 @@ define([
         url: url,
         displayRowIndex: true,
         gridOptions: {
-          editType: 'fullRow',
+          //editType: 'fullRow',
           singleClickEdit : true,
           rowData: rowData,
           rowSelection: (this.editable)? 'multiple' : '',

--- a/Front/app/ns_modules/ns_grid/grid.view.js
+++ b/Front/app/ns_modules/ns_grid/grid.view.js
@@ -99,11 +99,12 @@ define([
       this.gridOptions = {
         enableSorting: true,
         enableColResize: true,
-        editType: 'fullRow',
+        //editType: 'fullRow',
         rowHeight: 34,
         suppressNoRowsOverlay: true,
         headerHeight: 30,
         suppressRowClickSelection: true,
+        stopEditingWhenGridLosesFocus: true,
         onRowSelected: this.onRowSelected.bind(this),
         onDragStarted : this.onDragStarted.bind(this),
         onDragStopped: this.onDragStopped.bind(this),
@@ -295,7 +296,42 @@ define([
         }
       }
         col.comparator = comparator;
+        col.onCellValueChanged = function(event){
 
+          var column = event.colDef.field;
+          if(column == '_errors' ) { //skip col errors
+            return;
+          }
+
+          if( typeof(event.oldValue)==='undefined' ) { // no old value
+            if(event.newValue instanceof Object && !event.newValue.value) { // but we can have empty value like when leaving focus '' 
+                return;
+              }
+            if(!event.newValue) {
+              return;
+            }
+            window.formInEdition.form['.js-rg-grid'] = { "formChange" :true}
+            window.formInEdition.form['.js-rg-grid-subform'] = { "formChange" :true}
+          }
+
+          var newValue, oldValue;
+          if(event.newValue instanceof Object){
+            newValue = event.newValue.value;
+          } else {
+            newValue = event.newValue;
+          }
+          if(event.oldValue instanceof Object){
+            oldValue = event.oldValue.value;
+          } else {
+            oldValue = event.oldValue;
+          }
+
+          if(newValue !== oldValue){
+           window.formInEdition.form['.js-rg-grid'] = { "formChange" :true}
+           window.formInEdition.form['.js-rg-grid-subform'] = { "formChange" :true}
+          }
+        }
+        
         if(col.field == 'FK_ProtocoleType'){
           col.hide = true;
           return;
@@ -1122,7 +1158,7 @@ define([
           }
       };
 
-      AgGrid.PaginationController.prototype.createTemplate = function () {
+     /* AgGrid.PaginationController.prototype.createTemplate = function () {
           var localeTextFunc = this.gridOptionsWrapper.getLocaleTextFunc();
           var template = Backbone.Marionette.Renderer.render('app/ns_modules/ns_grid/pagination.tpl.html');
           return template
@@ -1134,7 +1170,7 @@ define([
               .replace('[PREVIOUS]', localeTextFunc('previous', 'Previous'))
               .replace('[NEXT]', localeTextFunc('next', 'Next'))
               .replace('[LAST]', localeTextFunc('last', 'Last'));
-      };
+      };*/
 
       AgGrid.extended = true;
     },

--- a/Front/app/ns_modules/ns_grid/grid.view.js
+++ b/Front/app/ns_modules/ns_grid/grid.view.js
@@ -310,8 +310,7 @@ define([
             if(!event.newValue) {
               return;
             }
-            window.formInEdition.form['.js-rg-grid'] = { "formChange" :true}
-            window.formInEdition.form['.js-rg-grid-subform'] = { "formChange" :true}
+            window.formInEdition.form['.js-obs-form'] = { "formChange" :true}
           }
 
           var newValue, oldValue;
@@ -327,8 +326,7 @@ define([
           }
 
           if(newValue !== oldValue){
-           window.formInEdition.form['.js-rg-grid'] = { "formChange" :true}
-           window.formInEdition.form['.js-rg-grid-subform'] = { "formChange" :true}
+            window.formInEdition.form['.js-obs-form'] = { "formChange" :true}
           }
         }
         

--- a/Front/bower.json
+++ b/Front/bower.json
@@ -26,7 +26,7 @@
     "tooltipster": "3.3.0",
     "chartjs": "1.0.2",
     "reneco-fonts": "*",
-    "ag-grid": "^5.2.0",
+    "ag-grid": "9.1.0",
     "NaturalJS_Filter":"1.1.4"
   },
   "resolutions": {


### PR DESCRIPTION
# **NEED UPGRADE AG-GRID FOR WORKING!!!!!!!!!!**

_**in front directory**_
_bower uninstall ag-grid && bower install ag-grid && grunt release && grunt watch_
_if bower ask you to choose version choose the version for ecoreleve (9.1)_




hack for simulate .js-obs-form.formChange = true
when edit grid

need help if we don't upgrade aggrid version to find another way than use :
"stopEditingWhenGridLosesFocus: true" in params of the grid

https://www.pivotaltracker.com/story/show/145456229