### PR TITLE
Fix thesau simple proto grid

### DIFF
--- a/Back/ecoreleve_server/Views/protocols.py
+++ b/Back/ecoreleve_server/Views/protocols.py
@@ -162,7 +162,7 @@ class ObservationsView(DynamicObjectCollectionView):
         for i in range(len(listObs)):
             curObs = listObs[i]
             curObs.LoadNowValues()
-            values.append(curObs.getFlatObject())
+            values.append(curObs.getFlatObject(schema=curObs.getForm().get('schema',None) ))
         return values
 
     def getProtocolsofStation(self):

--- a/Front/app/modules/stations/protocols/protocol.grid.view.js
+++ b/Front/app/modules/stations/protocols/protocol.grid.view.js
@@ -82,6 +82,7 @@ define([
         response.createdObservations.map(function(obs){
           _this.model.get('obs').push(obs.id);
         });
+        window.formInEdition.form['.js-obs-form'].formChange = false;
         this.model.trigger('change:obs', this.model);
         this.toggleEditionMode();
         this.hardRefresh();


### PR DESCRIPTION
Fix pb with simpleproto grid 

If getFlaObject didn't have schema , thesau val are not parsed :

So we get 
Taxon : 'very>very>very>long>path>for>a_word'

when we expect 

taxon : {
displayValue: 'a_word',
value: 'very>very>very>long>path>for>a_word'
}