### PR TITLE
Fix subobs savingpb

### DIFF
--- a/Back/ecoreleve_server/Models/Protocoles.py
+++ b/Back/ecoreleve_server/Models/Protocoles.py
@@ -119,7 +119,7 @@ class Observation(Base, ObjectWithDynProp):
                             subDictList.append(subDict)
                     curData['listOfSubObs'] = subDictList
 
-                if 'ID' in curData and curData['ID'] is not None:
+                if 'ID' in curData and curData['ID'] is not None and curData['ID'] != 0:
                     subObs = list(filter(lambda x: x.ID == curData[
                                   'ID'], self.Observation_children))[0]
                     subObs.LoadNowValues()

--- a/Front/app/vendors/backbone-forms.js
+++ b/Front/app/vendors/backbone-forms.js
@@ -1363,6 +1363,7 @@ Form.editors.Number = Form.editors.Text.extend({
   }),
 
   initialize: function(options) {
+    this.defaultValue = options.schema.defaultValue;
     Form.editors.Text.prototype.initialize.call(this, options);
 
     var schema = this.schema;


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/152671305

defaultValue  for number's input was 0 , change to null (if init with 0 , validators test value when saving and 0 not good for default value )

Subobs have and ID field but ID = 0 