### PR TITLE
FrontModules: fix a logical bug with isDisabled mode

### DIFF
--- a/Back/ecoreleve_server/GenericObjets/FrontModules.py
+++ b/Back/ecoreleve_server/GenericObjets/FrontModules.py
@@ -117,14 +117,10 @@ class ModuleForms(Base):
         isDisabled = False
 
         if self.Editable:
-
-            isDisabled = True
             if binaryTest(self.FormRender, 2) :
-                # input is inactive only in edit mode
-                if displayMode.lower() == 'edit':
+                # input is active only in edit mode
+                if displayMode.lower() != 'edit':
                     isDisabled = True
-                else:
-                    isDisabled = False
 
             if binaryTest(self.FormRender, 4):
 


### PR DESCRIPTION
j'ai pas bien compris le mic-mac avec displayMode/isDisabled/self.Editable et le binaryWeight.. mais à prioris y'a une erreur de logique quelquepart : je peux plus rien éditer sans ce patch