### PR TITLE
fix event triggered when autocomptree have date options or not

### DIFF
--- a/Front/app/ns_modules/ns_bbfe/bbfe-autocompTree.js
+++ b/Front/app/ns_modules/ns_bbfe/bbfe-autocompTree.js
@@ -168,7 +168,12 @@ define([
 
                     onItemClick: function (options) {
                         //for global
-                        _this.$el.find('input').trigger('thesaurusChange');
+                        if (_this.options.schema.options.date) {
+                            _this.$el.find('input').trigger('thesaurusChange');
+                        }
+                        else {
+                            _this.$el.find('input.autocompTree').trigger('thesaurusChange');
+                        }
 
                         _this.onChange();
                     },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155360455

`_this.$el.find('input').trigger('thesaurusChange'); `

was a problem now we have many input in template so we had to contextualize what we trigger and when