### PR TITLE
#158906548 : Suppression du champ age pour les individus et mise à jour des dépendances (requêtes, code...)

### DIFF
--- a/Back/database/Pipe/DB_Mother/211_ALTER_Individual_DROP_COLUMN_Age.txt
+++ b/Back/database/Pipe/DB_Mother/211_ALTER_Individual_DROP_COLUMN_Age.txt
@@ -1,0 +1,7 @@
+ALTER TABLE [dbo].[Individual] DROP COLUMN Age ;  
+
+GO
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('211_ALTER_Individual_DROP_COLUMN_Age',GETDATE(),(SELECT db_name()))
+
+GO

--- a/Back/database/Pipe/DB_Mother/211_ALTER_Individual_DROP_COLUMN_Age.txt
+++ b/Back/database/Pipe/DB_Mother/211_ALTER_Individual_DROP_COLUMN_Age.txt
@@ -5,3 +5,9 @@ GO
 INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('211_ALTER_Individual_DROP_COLUMN_Age',GETDATE(),(SELECT db_name()))
 
 GO
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('211_ALTER_Individual_DROP_COLUMN_Age',GETDATE(),(SELECT db_name()))
+
+
+GO

--- a/Back/database/Pipe/DB_Mother/212_DEL_age_input_for_IndivForm_in_moduleForms.txt
+++ b/Back/database/Pipe/DB_Mother/212_DEL_age_input_for_IndivForm_in_moduleForms.txt
@@ -1,10 +1,16 @@
 DELETE
-FROM [EcoReleve_ECWP].[dbo].[ModuleForms]
+FROM [dbo].[ModuleForms]
 WHERE [module_id] = (SELECT ID
-					 FROM [EcoReleve_ECWP].[dbo].[FrontModules]
+					 FROM [dbo].[FrontModules]
 					 WHERE [Name] = 'IndivForm')
 AND [TypeObj] is null
 AND [Name] = 'Age';
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('212_DEL_age_input_for_IndivForm_in_moduleForms',GETDATE(),(SELECT db_name()))
+
+
+GO
 
 
 INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('212_DEL_age_input_for_IndivForm_in_moduleForms',GETDATE(),(SELECT db_name()))

--- a/Back/database/Pipe/DB_Mother/212_DEL_age_input_for_IndivForm_in_moduleForms.txt
+++ b/Back/database/Pipe/DB_Mother/212_DEL_age_input_for_IndivForm_in_moduleForms.txt
@@ -1,0 +1,13 @@
+DELETE
+FROM [EcoReleve_ECWP].[dbo].[ModuleForms]
+WHERE [module_id] = (SELECT ID
+					 FROM [EcoReleve_ECWP].[dbo].[FrontModules]
+					 WHERE [Name] = 'IndivForm')
+AND [TypeObj] is null
+AND [Name] = 'Age';
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('212_DEL_age_input_for_IndivForm_in_moduleForms',GETDATE(),(SELECT db_name()))
+
+
+GO

--- a/Back/database/Pipe/DB_Mother/213_SP_MessageERDImportFromTrack_remove_Age.txt
+++ b/Back/database/Pipe/DB_Mother/213_SP_MessageERDImportFromTrack_remove_Age.txt
@@ -156,3 +156,10 @@ INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('213_
 
 
 GO
+
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('213_SP_MessageERDImportFromTrack_remove_Age',GETDATE(),(SELECT db_name()))
+
+
+GO

--- a/Back/database/Pipe/DB_Mother/213_SP_MessageERDImportFromTrack_remove_Age.txt
+++ b/Back/database/Pipe/DB_Mother/213_SP_MessageERDImportFromTrack_remove_Age.txt
@@ -1,0 +1,158 @@
+ALTER PROCEDURE [dbo].[MessageERDImportFromTrack]
+AS
+BEGIN
+	print 'MessageERDImportFromTrack'
+	
+	DECLARE @TInsetedId TABLE
+	(
+	Id INT
+	)
+	
+	BEGIN TRY
+	BEGIN TRAN
+		------------------------- GESTION DES SUJETS -------------------------
+		print 'Individu insertion'
+		-- Insertion des nouveaux sujets
+		INSERT INTO [Individual]
+			   (
+			   [creationDate]
+			   --,[Age]
+			   ,[Birth_date]
+			   ,[Death_date]
+			   ,[FK_IndividualType]
+			   ,[Species]
+			   ,Original_ID
+			   )
+			  OUTPUT inserted.ID into @TInsetedId
+		SELECT distinct 
+			Getdate(),
+			--NULL,
+			CONVERT(DATETIME,BD.PropValue,120) ,
+			NULL,
+			1,
+			E.PropValue,m.Provenance +'_'+CONVERT(VARCHAR,M.objectID)
+		FROM  TMessageReceived M 
+	--	JOIN  TMessageReceivedDetail S ON M.pk_MessageReceived=S.fk_MessageReceived and S.PropName = 'TInd_Sexe'
+		JOIN  TMessageReceivedDetail BD ON M.pk_MessageReceived=BD.fk_MessageReceived and BD.provenance = m.provenance and BD.PropName = 'TInd_DateNaissance' 
+		JOIN  TMessageReceivedDetail E ON M.pk_MessageReceived=E.fk_MessageReceived and E.provenance = m.provenance and E.PropName = 'TInd_Espece'  
+		WHERE Importdate IS NULL AND M.ObjectType ='Individu' AND m.Provenance LIKE 'TRACK_%'
+		AND NOT EXISTS (SELECT * FROM [Individual] S WHERE [FK_IndividualType] =1 and S.Original_ID = m.Provenance +'_' +CONVERT(VARCHAR,m.ObjectId))
+		
+
+		print 'Inserting DYnPropValues'
+		-- INserttion  des propriétées dynamiques 
+		INSERT INTO [IndividualDynPropValue]
+			   ([StartDate]
+			   ,[ValueInt]
+			   ,[ValueString]
+			   ,[ValueDate]
+			   ,[ValueFloat]
+			   ,FK_Individual
+			   ,FK_IndividualDynProp)
+		SELECT distinct  GETDATE()
+		,CASE WHEN DP.TypeProp = 'integer' THEN CONVERT(int,D.PropValue) ELSE NULL END
+		,CASE WHEN DP.TypeProp = 'string' THEN D.PropValue ELSE NULL END
+		,CASE WHEN DP.TypeProp = 'date' THEN CONVERT(DATETIME,D.PropValue,120) ELSE NULL END
+		,CASE WHEN DP.TypeProp = 'float' THEN CONVERT(float,D.PropValue) ELSE NULL END
+		,I.ID
+		,DP.ID
+		FROM 	TMessageReceived M 
+		JOIN Individual I on I.Original_Id = M.Provenance+'_' + CONVERT(VARCHAR,m.ObjectId)
+		JOIN  TMessageReceivedDetail D ON M.pk_MessageReceived=D.fk_MessageReceived and D.provenance = m.provenance
+		JOIN TMessageDynPropvsTrack CDP ON CDP.TrackName = D.PropName
+		JOIN IndividualDynProp DP ON CDP.ERDName = DP.Name
+		WHERE Importdate IS NULL AND M.ObjectType ='individu' AND m.Provenance LIKE 'TRACK_%'
+		AND i.ID in (select ID FROM @TInsetedId)
+
+
+		INSERT INTO [IndividualDynPropValue]
+			   ([StartDate]
+			   ,[ValueInt]
+			   ,[ValueString]
+			   ,[ValueDate]
+			   ,[ValueFloat]
+			   ,FK_Individual
+			   ,FK_IndividualDynProp)
+		SELECT distinct  GETDATE()
+		,NULL
+		,'release'
+		,NULL
+		,NULL
+		,I.ID
+		,(SELECT ID FROM IndividualDynProp WHERE Name = 'Origin')
+		FROM 	TMessageReceived M 
+		JOIN Individual I on I.Original_Id = M.Provenance+'_' + CONVERT(VARCHAR,m.ObjectId)
+		WHERE Importdate IS NULL AND M.ObjectType ='individu' AND m.Provenance LIKE 'TRACK_%'
+		AND i.ID in (select ID FROM @TInsetedId)
+		
+
+		Update v set ValueString = th.TTop_FullPath
+		--SELECT v.ValueString
+		--,dp.Name
+		--,f.Options
+		--,th.TTop_FullPath 
+		FROM IndividualDynPropValue v
+		JOIN dbo.IndividualDynProp dp ON v.FK_IndividualDynProp = dp.ID
+		JOIN dbo.Individual i on v.FK_Individual = I.ID
+		JOIN ModuleForms f on f.Name = dp.Name and f.InputType = 'AutocompTreeEditor' and f.module_id = 9
+		LEFT join THESAURUS.dbo.VTopicCompatibility th 
+			ON th.TTop_PK_ID> 204082
+			and f.Options = th.TTop_ParentID AND (v.ValueString like th.TTop_NameEn )
+		WHERE  i.Original_ID like 'track%' 
+			and i.ID in (select ID FROM @TInsetedId)
+		AND th.TTop_FullPath IS NOT NULL 
+
+
+		UPDATE i SET i.Species = th.TTop_FullPath
+		FROM Individual i
+		JOIN ModuleForms f ON f.Name = 'Species' and f.module_id = 9
+		--JOIN ModuleForms f2 ON f2.Name = 'Age' and f.module_id = 9
+		JOIN THESAURUS.dbo.VTopicCompatibility th 
+			ON th.TTop_PK_ID> f.Options
+			 AND (Species = th.TTop_Name)
+		WHERE  i.Original_ID like 'track%'
+			 and i.ID in (select ID FROM @TInsetedId)
+		AND th.TTop_FullPath IS NOT NULL 
+
+
+		UPDATE TMessageReceived
+		SET ImportDate=GETDATE()
+		WHERE ObjectType ='Individu'
+		AND ImportDate IS NULL AND Provenance LIKE 'TRACK_%'
+		
+		commit tran
+	END TRY
+		BEGIN CATCH
+			print 'CATCH'
+			print @@TRANCOUNT
+			IF @@TRANCOUNT >0  ROLLBACK TRAN;
+			print @@TRANCOUNT
+			
+			DECLARE @ErrorMessage NVARCHAR(4000);
+			DECLARE @ErrorSeverity INT;
+			DECLARE @ErrorState INT;
+			
+			SELECT 
+				@ErrorMessage = ERROR_MESSAGE(),
+				@ErrorSeverity = ERROR_SEVERITY(),
+				@ErrorState = ERROR_STATE();
+			
+			RAISERROR (@ErrorMessage, -- Message text.
+					   @ErrorSeverity, -- Severity.
+					   @ErrorState -- State.
+					   );
+		END CATCH	
+	
+
+END
+
+
+
+
+
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('213_SP_MessageERDImportFromTrack_remove_Age',GETDATE(),(SELECT db_name()))
+
+
+GO

--- a/Back/database/Stored Procedure/ImportERD.sql
+++ b/Back/database/Stored Procedure/ImportERD.sql
@@ -21,7 +21,7 @@ BEGIN
 		INSERT INTO [Individual]
 			   (
 			   [creationDate]
-			   ,[Age]
+			   --,[Age]
 			   ,[Birth_date]
 			   ,[Death_date]
 			   ,[FK_IndividualType]
@@ -29,7 +29,8 @@ BEGIN
 			   ,Original_ID
 			   ,Caisse_ID)
 			  OUTPUT inserted.ID into @TInsetedId
-		SELECT distinct Getdate(),NULL,CONVERT(DATETIME,BD.PropValue,120) ,NULL,1,E.PropValue,m.Provenance +'_'+CONVERT(VARCHAR,M.objectID),NULL
+		--SELECT distinct Getdate(),NULL,CONVERT(DATETIME,BD.PropValue,120) ,NULL,1,E.PropValue,m.Provenance +'_'+CONVERT(VARCHAR,M.objectID),NULL
+		SELECT distinct Getdate(),CONVERT(DATETIME,BD.PropValue,120) ,NULL,1,E.PropValue,m.Provenance +'_'+CONVERT(VARCHAR,M.objectID),NULL
 		FROM  TMessageReceived M 
 	--	JOIN  TMessageReceivedDetail S ON M.pk_MessageReceived=S.fk_MessageReceived and S.PropName = 'TInd_Sexe'
 		JOIN  TMessageReceivedDetail BD ON M.pk_MessageReceived=BD.fk_MessageReceived and BD.PropName = 'TInd_DateNaissance'
@@ -39,7 +40,7 @@ BEGIN
 		
 
 		print 'Inserting DYnPropValues'
-		-- INserttion  des propriétées dynamiques 
+		-- INserttion  des propriï¿½tï¿½es dynamiques 
 		INSERT INTO [IndividualDynPropValue]
 			   ([StartDate]
 			   ,[ValueInt]

--- a/Back/ecoreleve_server/Models/Individual.py
+++ b/Back/ecoreleve_server/Models/Individual.py
@@ -44,7 +44,7 @@ class Individual (HasDynamicProperties, Base):
     ID = Column(Integer, Sequence('Individual__id_seq'), primary_key=True)
     creationDate = Column(DateTime, nullable=False, default=func.now())
     Species = Column(String(250))
-    Age = Column(String(250))
+    #Age = Column(String(250))
     Birth_date = Column(Date)
     Death_date = Column(Date)
     Original_ID = Column(String(250))

--- a/Back/ecoreleve_server/Views/release.py
+++ b/Back/ecoreleve_server/Views/release.py
@@ -132,7 +132,7 @@ class ReleaseIndividualsView(IndividualsView):
         """
         def MoF_AoJ(obj):
             curSex = None
-            curAge = None
+            #curAge = None
             binP = 0
             if obj['Sex'] is not None and obj['Sex'].lower() == 'male':
                 curSex = 'male'
@@ -144,6 +144,7 @@ class ReleaseIndividualsView(IndividualsView):
                 curSex == 'Indeterminate'
                 binP += 1
 
+            """
             if obj['Age'] is not None and obj['Age'].lower() == 'Adult':
                 curAge = 'Adult'
                 binP += 8
@@ -153,6 +154,7 @@ class ReleaseIndividualsView(IndividualsView):
             else:
                 curAge == 'Indeterminate'
                 binP += 32
+            """
             return binaryDict[binP]
 
         try:

--- a/Back/ecoreleve_server/modules/individuals/individual_model.py
+++ b/Back/ecoreleve_server/modules/individuals/individual_model.py
@@ -45,7 +45,7 @@ class Individual (HasDynamicProperties, Base):
     ID = Column(Integer, Sequence('Individual__id_seq'), primary_key=True)
     creationDate = Column(DateTime, nullable=False, default=func.now())
     Species = Column(String(250))
-    Age = Column(String(250))
+    #Age = Column(String(250))
     Birth_date = Column(Date)
     Death_date = Column(Date)
     Original_ID = Column(String(250), default='0')

--- a/Back/ecoreleve_server/modules/release/release_resource.py
+++ b/Back/ecoreleve_server/modules/release/release_resource.py
@@ -133,7 +133,7 @@ class ReleaseIndividualsResource(IndividualsResource):
         """
         def MoF_AoJ(obj):
             curSex = None
-            curAge = None
+            #curAge = None
             binP = 0
             if obj['Sex'] is not None and obj['Sex'].lower() == 'male':
                 curSex = 'male'
@@ -145,6 +145,7 @@ class ReleaseIndividualsResource(IndividualsResource):
                 curSex == 'Indeterminate'
                 binP += 1
 
+            """
             if obj['Age'] is not None and obj['Age'].lower() == 'Adult':
                 curAge = 'Adult'
                 binP += 8
@@ -154,6 +155,7 @@ class ReleaseIndividualsResource(IndividualsResource):
             else:
                 curAge == 'Indeterminate'
                 binP += 32
+            """
             return binaryDict[binP]
 
         try:


### PR DESCRIPTION
- Création d'un script de modification du schema de la base pour la table individus : pipe 211
- Création d'un script de suppression de l'input age pour le formulaire de création des individus : pipe 212
- Suppression de la propriété Age du model Individual dans l'API
- Suppression de la prise en compte de l'Age dans la création des individus et dans le release
- Suppression de la prise en compte de l'Age dans les différents affichages des individus dans le front : aucun modif faite dans le front
- Répercuter les modifications dans la base export : pip 213