### PR TITLE
hotfix : Saisie d'individu non identifié

### DIFF
--- a/Back/database/Pipe/DB_Mother/211_update_ModuleGrids_typeObj_for_IndivFilterID.txt
+++ b/Back/database/Pipe/DB_Mother/211_update_ModuleGrids_typeObj_for_IndivFilterID.txt
@@ -1,0 +1,9 @@
+UPDATE [dbo].[ModuleGrids]
+SET [TypeObj] = NULL
+WHERE [Module_ID] = 8 and [Name] = 'ID';
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('211_update_ModuleGrids_typeObj_for_IndivFilterID',GETDATE(),(SELECT db_name()))
+
+
+GO


### PR DESCRIPTION
Le bug provenait du fait que dans ModuleGrids le typeobj pour récupérer l'id des individus était à 1, donc l'id était récupéré uniquement pour les individus identifiés. J'ai mis le typeobj à null pour que l'attribut id soit dispo pour les indiv identifiés et non-identifiés.

Rappel mail "bug saisi ecoR" :
À la sélection d’un individu non identifié, on revient au formulaire, mais l’ID de l’individu non identifié sélectionné ne s’affiche pas dans le protocole.
+
Lors de la saisie d’un protocole Vertebrate individual death (testé sur le protocole Vertebrate group, même résultat) on ne peut plus saisir d’individu non identifié. La recherche des critères marche, mais on ne peut pas sélectionner d’individu.