### PR TITLE
Implémentation  de la prise en charge du champ active pour les sites monitorés dans l'application

### DIFF
--- a/Back/database/Pipe/DB_Mother/211_MonitoredSites_insert_Active_checkbox_in_form.txt
+++ b/Back/database/Pipe/DB_Mother/211_MonitoredSites_insert_Active_checkbox_in_form.txt
@@ -1,0 +1,51 @@
+INSERT INTO [dbo].[ModuleForms]
+           ([module_id]
+           ,[TypeObj]
+           ,[Name]
+           ,[Label]
+           ,[Required]
+           ,[FieldSizeEdit]
+           ,[FieldSizeDisplay]
+           ,[InputType]
+           ,[editorClass]
+           ,[FormRender]
+           ,[FormOrder]
+           ,[Legend]
+           ,[Options]
+           ,[Validators]
+           ,[displayClass]
+           ,[EditClass]
+           ,[Status]
+           ,[Locked]
+           ,[DefaultValue]
+           ,[Rules]
+           ,[Orginal_FB_ID])
+     VALUES
+           (12
+           ,NULL
+           ,'Active'
+           ,'Active'
+           ,'False'
+           ,3
+           ,3
+           ,'Checkbox'
+           ,'form-control'
+           ,7
+           ,2
+           ,'General Infos'
+           ,NULL
+           ,NULL
+           ,NULL
+           ,NULL
+           ,NULL
+           ,'True'
+           ,NULL
+           ,NULL
+           ,NULL)
+GO
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('211_MonitoredSites_insert_Active_checkbox_in_form',GETDATE(),(SELECT db_name()))
+
+
+GO


### PR DESCRIPTION
id pivotal : #157964896

- Modification de la conf du formulaire pour la création et l'edition d'un site monitoré en ajoutant un input de type checkbox : creation pipe 211_MonitoredSites_insert_Active_checkbox_in_form

- Prise en charge du champ coté back et coté front : pas besoin normalement ça fonctionne sans modif