### PR TITLE
Amélioration de la procédure de suppression des individus d'un bridge ayant subi un échec

### DIFF
--- a/Back/database/Pipe/DB_Mother/211_ALTER_PR_deleteIndividualsBridgeFailed.txt
+++ b/Back/database/Pipe/DB_Mother/211_ALTER_PR_deleteIndividualsBridgeFailed.txt
@@ -1,0 +1,74 @@
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER PROCEDURE [dbo].[pr_DeleteIndividualsBridgeFailed]
+	--@DateBridgeFailed varchar(max)
+
+AS
+BEGIN
+	BEGIN TRAN
+	BEGIN TRY
+
+
+		IF type_id('[dbo].[IndividualsBridgeType]') IS NOT NULL
+				DROP TYPE [dbo].[IndividualsBridgeType]
+
+		CREATE TYPE [dbo].[IndividualsBridgeType] AS TABLE
+			(
+				ID_Individual int
+			)
+		
+		DECLARE @Individuals AS IndividualsBridgeType
+
+		INSERT INTO @Individuals
+		SELECT ID 
+		FROM [dbo].[Individual]
+		WHERE creationDate < (GETDATE() - 5) AND Original_ID like '%TRACK%'
+
+		EXEC [dbo].[pr_DeleteAllDataFromIdIndividual] @Individuals
+
+	COMMIT TRAN
+	END TRY	
+
+	BEGIN CATCH
+		ROLLBACK TRAN
+
+		DECLARE @ErrorMessage NVARCHAR(4000)
+		DECLARE @ErrorSeverity INT;
+		DECLARE @ErrorState INT;
+
+		SELECT @ErrorMessage = ERROR_MESSAGE(),
+			   @ErrorSeverity = ERROR_SEVERITY(),
+			   @ErrorState = ERROR_STATE();
+
+		INSERT INTO [NSLOG].[dbo].TLOG_MESSAGES
+		VALUES(
+			GETDATE(),
+			@ErrorSeverity,
+			'EcoReleve',
+			'SP : sp_DeleteIndividualsBridgeFailed',
+			SUser_SName(),
+			2,
+			@ErrorState,
+			@ErrorMessage,
+			null
+			)
+	
+		RAISERROR (@ErrorMessage, -- Message text.
+				   @ErrorSeverity, -- Severity.
+				   @ErrorState -- State.
+				   );
+	END CATCH
+	 
+	
+END
+GO
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('211_ALTER_PR_deleteIndividualsBridgeFailed',GETDATE(),(SELECT db_name()))
+
+
+GO

--- a/Back/database/Pipe/DB_Mother/212_ALTER_PR_deleteAllDataFromIdIndividual.txt
+++ b/Back/database/Pipe/DB_Mother/212_ALTER_PR_deleteAllDataFromIdIndividual.txt
@@ -1,0 +1,139 @@
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER PROCEDURE [dbo].[pr_DeleteAllDataFromIdIndividual]
+@IndividualsTable IndividualsBridgeType READONLY
+
+AS
+BEGIN
+
+		-- élimination des données concernées
+		BEGIN TRAN
+		BEGIN TRY
+				
+				DELETE
+				FROM [dbo].[Individual_Location]
+				WHERE FK_Individual IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				--print 'ok Individual_Location'
+
+				DELETE 
+				FROM [dbo].[IndividualDynPropValue]
+				WHERE FK_Individual IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				--print 'ok IndividualDynPropValue'
+
+				DELETE 
+				FROM [dbo].[Equipment]
+				WHERE FK_Individual IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				--print 'ok Equipment'
+				
+				----- replace loop of the previous PR version -----
+				DELETE odpsv
+				FROM [dbo].[ObservationDynPropSubValue] odpsv
+				LEFT JOIN [dbo].[Observation] o ON odpsv.FK_Observation = o.id
+				WHERE o.FK_Individual IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+
+				DELETE odpv
+				FROM [dbo].[ObservationDynPropValue] odpv
+				LEFT JOIN [dbo].[Observation] o ON odpv.FK_Observation = o.id
+				WHERE o.FK_Individual IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				----------------------------------------------------
+
+				DELETE 
+				FROM [dbo].[Observation]
+				WHERE FK_Individual IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				--print 'ok Observation'
+
+				DELETE 
+				FROM [dbo].[Individual]
+				WHERE ID IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				--print 'ok Individual'
+
+				----- set to NULL the TMessageReceived.importDate value for individuals involved in this PR -----
+				UPDATE [dbo].[TMessageReceived]
+				SET ImportDate = NULL
+				WHERE ObjectId  IN
+					(
+					SELECT ID_Individual
+					FROM @IndividualsTable
+					)
+				-------------------------------------------------------------------------------------------------
+
+				
+
+			COMMIT TRAN
+			END TRY
+
+			BEGIN CATCH
+				ROLLBACK TRAN
+
+				DECLARE @ErrorMessage NVARCHAR(4000)
+				DECLARE @ErrorSeverity INT;
+				DECLARE @ErrorState INT;
+
+				SELECT @ErrorMessage = ERROR_MESSAGE(),
+					   @ErrorSeverity = ERROR_SEVERITY(),
+					   @ErrorState = ERROR_STATE();
+
+				----- add error  in NSLOG.TLOG_MESSAGES ----
+				INSERT INTO [NSLOG].[dbo].[TLOG_MESSAGES]
+				VALUES(
+					GETDATE(),
+					@ErrorSeverity,
+					'EcoReleve',
+					'SP : sp_DeleteAllDataFromIdIndividual',
+					SUser_SName(),
+					2,
+					@ErrorState,
+					@ErrorMessage,
+					null
+					)
+				--------------------------------------------
+
+				RAISERROR (@ErrorMessage, -- Message text.
+						   @ErrorSeverity, -- Severity.
+						   @ErrorState -- State.
+						   );
+			END CATCH
+	
+END
+GO
+
+
+
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('212_ALTER_PR_deleteAllDataFromIdIndividual',GETDATE(),(SELECT db_name()))
+
+
+GO


### PR DESCRIPTION
id pivotal : #160691002

modification de 2 PR :
- suppression par groupe (table en input parameter de la pr_deletealldatafromindividual dans la pr_DeleteIndividualsBridgeFailed)
- suppression des boucles while exists
- tlog
- le champ ImportDate a une valeur NULL pour les individus concernés dans la table
- (vérification pour les oiseaux créés il y a moins de 5 jours était déjà fait)