### PR TITLE
Fixforfieldworkareahd

### DIFF
--- a/Back/database/Pipe/DB_Mother/220_UPDATE_CONF_FilterFieldworkArea_On_Name.txt
+++ b/Back/database/Pipe/DB_Mother/220_UPDATE_CONF_FilterFieldworkArea_On_Name.txt
@@ -1,0 +1,13 @@
+UPDATE [ModuleGrids]
+SET [Name] = 'FieldworkArea@Name',
+	[Options] = '{"source": "autocomplete/fieldworkarea/Name/Name", "minLength":3}'
+WHERE
+[Module_ID] = 3
+AND
+[name] = 'FieldworkArea@fullpath'
+
+
+INSERT INTO [dbo].[TVersion] (TVer_FileName,TVer_Date,TVer_DbName) VALUES ('220_UPDATE_CONF_FilterFieldworkArea_On_Name',GETDATE(),(SELECT db_name()))
+
+
+GO

--- a/Back/ecoreleve_server/modules/regions/region_resource.py
+++ b/Back/ecoreleve_server/modules/regions/region_resource.py
@@ -41,10 +41,32 @@ class RegionResource(CustomResource):
             return 'reference not found'
 
     def getGeoJson(self):
-        return self.objectDB.geom_json
+        item = self.objectDB
+        toRet = Feature(
+                id=getattr(item, 'ID'),
+                geometry=wkb.loads(getattr(item, 'valid_geom')),
+                properties={
+                    'FieldworkArea': getattr(item, 'fullpath'),
+                    'Country': getattr(item, 'Country'),
+                    'Working_area': getattr(item, 'Working_Area'),
+                    'Working_region': getattr(item, 'Working_Region'),
+                    'Management_unit': getattr(item, 'Management_Unit'),
+                    'name': getattr(item, 'Name')
+                }
+            )
+        return toRet
 
     def retrieve(self):
-        return self.objectDB.json
+        toRet = {
+            'FieldworkArea': getattr(self.objectDB, 'fullpath', None),
+            'Country': getattr(self.objectDB, 'Country', None),
+            'Working_area': getattr(self.objectDB, 'Working_Area', None),
+            'Working_region': getattr(self.objectDB, 'Working_Region', None),
+            'Management_unit': getattr(self.objectDB, 'Management_Unit', None),
+            'Name': getattr(self.objectDB, 'Name', None),
+            }
+
+        return toRet
 
 
 class RegionsResource(CustomResource):


### PR DESCRIPTION
## Fix for fieldworkarea 

pipe sql for update filter FieldworkArea on station's grid 
Now we display and filter on Name no more on fullpath

Back end : fix for returning object expected by FieldworkingAreaEditor